### PR TITLE
Potential fix for code scanning alert no. 90: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-maven.yml
+++ b/.github/workflows/deploy-maven.yml
@@ -1,4 +1,6 @@
 name: deploy-maven
+permissions:
+  contents: read
 on:
   push:
     # ToDo: Replace with tag


### PR DESCRIPTION
Potential fix for [https://github.com/zoom/zoom-data-fence/security/code-scanning/90](https://github.com/zoom/zoom-data-fence/security/code-scanning/90)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to the least privileges required for the workflow. Since the workflow involves publishing packages and accessing secrets, the `contents: read` permission is sufficient for accessing repository contents, and no write permissions are needed.

The `permissions` block should be added at the top level of the workflow file, ensuring it applies to all jobs unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
