### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/zoom/zoom-data-fence/security/code-scanning/5](https://github.com/zoom/zoom-data-fence/security/code-scanning/5)

To fix the issue, add a `permissions` block to the workflow file. Since the workflow involves checking out code and building it, the minimal permissions required are `contents: read`. This ensures the workflow can read the repository contents without granting unnecessary write access.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. Alternatively, it can be added to the specific job if different jobs require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
