### PR TITLE
Potential fix for code scanning alert no. 114: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -7,6 +7,8 @@ on:
     tags:
       # Build Releases From Tags
       - v*.*.*
+permissions:
+  contents: read
 jobs:
   get-version:
     environment: deploy


### PR DESCRIPTION
Potential fix for [https://github.com/zoom/zoom-data-fence/security/code-scanning/114](https://github.com/zoom/zoom-data-fence/security/code-scanning/114)

To fix the problem, add a `permissions` block at the top level of the workflow file, immediately after the `name` and `on` keys. This block should specify the minimal permissions required for the workflow to function. If the workflow only needs to read repository contents (which is the most common minimal case), set `contents: read`. If any job or step requires additional permissions (such as writing to pull requests or issues), those should be added as needed. Since the provided workflow does not show any steps that require write access, starting with `contents: read` is appropriate. This change should be made at the root of `.github/workflows/build-deploy.yml`, before the `jobs:` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
