### PR TITLE
Add tar support for AWS CLI variant

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,7 +118,7 @@ jobs:
         if: matrix.variant == 'aws-cli'
         run: |
           echo "Testing tar command availability..."
-          docker run --rm --entrypoint bash test-image:${{ matrix.variant }} -c "tar --version"
+          docker run --rm --entrypoint bash test-image:${{ matrix.variant }} -c "tar --help > /dev/null && echo 'tar is working'"
           docker run --rm --entrypoint bash test-image:${{ matrix.variant }} -c "command -v tar"
       
       - name: Validate tar command not available (standard variant only)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           echo "Testing tar command availability..."
           docker run --rm --entrypoint bash test-image:${{ matrix.variant }} -c "tar --version"
-          docker run --rm --entrypoint bash test-image:${{ matrix.variant }} -c "which tar"
+          docker run --rm --entrypoint bash test-image:${{ matrix.variant }} -c "command -v tar"
       
       - name: Validate tar command not available (standard variant only)
         if: matrix.variant == 'standard'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,19 @@ jobs:
           echo "Testing AWS CLI installation..."
           docker run --rm --entrypoint bash test-image:${{ matrix.variant }} -c "aws --version"
       
+      - name: Validate tar command (aws-cli variant only)
+        if: matrix.variant == 'aws-cli'
+        run: |
+          echo "Testing tar command availability..."
+          docker run --rm --entrypoint bash test-image:${{ matrix.variant }} -c "tar --version"
+          docker run --rm --entrypoint bash test-image:${{ matrix.variant }} -c "which tar"
+      
+      - name: Validate tar command not available (standard variant only)
+        if: matrix.variant == 'standard'
+        run: |
+          echo "Testing tar command is NOT available in standard variant..."
+          docker run --rm --entrypoint bash test-image:${{ matrix.variant }} -c "! command -v tar" || (echo "tar should not be available in standard variant" && exit 1)
+      
       - name: Validate file permissions
         run: |
           echo "Testing file permissions..."

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 COPY ${JAR_PATH} ${DFENCE_JAR_PATH}
 COPY dfence /usr/bin/dfence
 RUN if [ "$INSTALL_AWS_CLI" = "true" ]; then \
-        yum update -y && yum install -y unzip && \
+        yum update -y && yum install -y unzip tar && \
         ARCH=$(uname -m) && \
         if [ "$ARCH" = "x86_64" ]; then \
             curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \


### PR DESCRIPTION
Add tar support to AWS CLI variant

- Install tar alongside unzip in AWS CLI variant
- Add tests to verify tar availability in aws-cli variant
- Add tests to confirm tar is not available in standard variant