### PR TITLE
Fix SHOW GRANTS parsing for Snowflake BCR 2026_01 (bcr-2190)

### DIFF
--- a/src/main/java/us/zoom/data/dfence/sql/ObjectName.java
+++ b/src/main/java/us/zoom/data/dfence/sql/ObjectName.java
@@ -135,7 +135,15 @@ public class ObjectName {
         if (procedureName.isEmpty()) {
             return "";
         }
-        SqlObject sqlObject = ObjectName.parseSqlObjectFromShowGrantsProcedureName(procedureName);
+        // Try parsing as the new format first (BCR-2190: DB.SCHEMA.NAME(TYPES))
+        SqlObject sqlObject = ObjectName.parseSqlObject(procedureName);
+        if (sqlObject.isHasArguments()) {
+            // New format: already has parsed arguments, just normalize
+            return sqlObject.normalizedName();
+        }
+        // Old format: DB.SCHEMA."NAME(ARG_NAME TYPE, ...):RETURN_TYPE"
+        // The callable signature is inside a quoted identifier, needs special parsing
+        sqlObject = ObjectName.parseSqlObjectFromShowGrantsProcedureName(procedureName);
         return sqlObject.normalizedName();
     }
 

--- a/src/test/java/us/zoom/data/dfence/providers/snowflake/SnowflakeGrantsServiceTest.java
+++ b/src/test/java/us/zoom/data/dfence/providers/snowflake/SnowflakeGrantsServiceTest.java
@@ -141,6 +141,92 @@ class SnowflakeGrantsServiceTest {
     }
 
     @Test
+    void getGrantsWithNewFormatProcedureName() throws SQLException {
+        String roleName = "MOCK_ROLE";
+        Boolean skipUnkownTypes = true;
+        try (Statement currentGrantsStatement = Mockito.mock(Statement.class)) {
+            try (Statement futureGrantsStatement = Mockito.mock(Statement.class)) {
+                when(snowflakeConnection.createStatement()).thenReturn(currentGrantsStatement, futureGrantsStatement);
+                List columnNames = List.of(
+                        "privilege",
+                        "granted_on",
+                        "name",
+                        "granted_to",
+                        "grantee_name",
+                        "grant_option");
+                // BCR-2190: New format — DB.SCHEMA.NAME(TYPES) without quotes, arg names, or return type
+                when(currentGrantsStatement.getResultSet()).thenReturn(new MockResultSet(
+                        List.of(
+                                List.of(
+                                        new I("USAGE"),
+                                        new I("PROCEDURE"),
+                                        new I("MOCK_DB.MOCK_SCHEMA.MOCK_PROC(VARCHAR, NUMBER)"),
+                                        new I("ROLE"),
+                                        new I("MOCK_ROLE"),
+                                        new I(false))),
+                        columnNames));
+                when(futureGrantsStatement.getResultSet()).thenReturn(new MockResultSet(List.of(), columnNames));
+                SnowflakeGrantBuilderOptions options = new SnowflakeGrantBuilderOptions();
+                SnowflakeGrantBuilder builder = new SnowflakePermissionGrantBuilder(new SnowflakeGrantModel(
+                        "USAGE",
+                        "PROCEDURE",
+                        "MOCK_DB.MOCK_SCHEMA.MOCK_PROC(VARCHAR, NUMBER)",
+                        "ROLE",
+                        "MOCK_ROLE",
+                        false,
+                        false,
+                        false), options);
+                Map<String, SnowflakeGrantBuilder> expected = Map.of(builder.getKey(), builder);
+                Map<String, SnowflakeGrantBuilder> actual = snowflakeGrantsService.getGrants(roleName, skipUnkownTypes);
+                assertEquals(expected, actual);
+            }
+        }
+    }
+
+    @Test
+    void getGrantsWithOldFormatProcedureName() throws SQLException {
+        String roleName = "MOCK_ROLE";
+        Boolean skipUnkownTypes = true;
+        try (Statement currentGrantsStatement = Mockito.mock(Statement.class)) {
+            try (Statement futureGrantsStatement = Mockito.mock(Statement.class)) {
+                when(snowflakeConnection.createStatement()).thenReturn(currentGrantsStatement, futureGrantsStatement);
+                List columnNames = List.of(
+                        "privilege",
+                        "granted_on",
+                        "name",
+                        "granted_to",
+                        "grantee_name",
+                        "grant_option");
+                // Old format — DB.SCHEMA."NAME(ARG_NAME TYPE, ...):RETURN_TYPE"
+                when(currentGrantsStatement.getResultSet()).thenReturn(new MockResultSet(
+                        List.of(
+                                List.of(
+                                        new I("USAGE"),
+                                        new I("PROCEDURE"),
+                                        new I("MOCK_DB.MOCK_SCHEMA.\"MOCK_PROC(FROM_TABLE VARCHAR, COUNT NUMBER):VARCHAR\""),
+                                        new I("ROLE"),
+                                        new I("MOCK_ROLE"),
+                                        new I(false))),
+                        columnNames));
+                when(futureGrantsStatement.getResultSet()).thenReturn(new MockResultSet(List.of(), columnNames));
+                SnowflakeGrantBuilderOptions options = new SnowflakeGrantBuilderOptions();
+                SnowflakeGrantBuilder builder = new SnowflakePermissionGrantBuilder(new SnowflakeGrantModel(
+                        "USAGE",
+                        "PROCEDURE",
+                        "MOCK_DB.MOCK_SCHEMA.MOCK_PROC(VARCHAR, NUMBER)",
+                        "ROLE",
+                        "MOCK_ROLE",
+                        false,
+                        false,
+                        false), options);
+                Map<String, SnowflakeGrantBuilder> expected = Map.of(builder.getKey(), builder);
+                Map<String, SnowflakeGrantBuilder> actual = snowflakeGrantsService.getGrants(roleName, skipUnkownTypes);
+                assertEquals(expected, actual);
+            }
+        }
+    }
+
+    @Test
     void filterUnsupportedObjectGrantType() throws SQLException {
         String roleName = "MOCK_ROLE";
         Boolean skipUnkownTypes = true;

--- a/src/test/java/us/zoom/data/dfence/sql/ObjectNameTest.java
+++ b/src/test/java/us/zoom/data/dfence/sql/ObjectNameTest.java
@@ -140,7 +140,16 @@ class ObjectNameTest {
                     "SNOWFLAKE.CORE.\"AVG(ARG_T TABLE(TABLE(FLOAT)), ARG2 TABLE(FLOAT, VARCHAR, NUMBER(38,2))):FLOAT\";SNOWFLAKE.CORE.AVG(TABLE(TABLE(FLOAT)), TABLE(FLOAT, VARCHAR, NUMBER(38,2)))",
                     "SNOWFLAKE.CORE.\"avg123%(ARG_T TABLE(FLOAT), ARG2 TABLE(FLOAT, VARCHAR, NUMBER(38,2))):FLOAT\";SNOWFLAKE.CORE.\"avg123%\"(TABLE(FLOAT), TABLE(FLOAT, VARCHAR, NUMBER(38,2)))",
                     "FOO.BAR.\"DUPLICATE_COUNT(ARG_T TABLE(ARG_C FLOAT)):NUMBER(38,0)\";FOO.BAR.DUPLICATE_COUNT(TABLE(FLOAT))",
-                    "FOO.BAR.\"ZAR()\";FOO.BAR.ZAR()"}, delimiter = ';')
+                    "FOO.BAR.\"ZAR()\";FOO.BAR.ZAR()",
+                    // New format (BCR-2190): DB.SCHEMA.NAME(TYPES) — no quotes, no arg names, no return type
+                    "MY_DB.MY_SCHEMA.AREA_OF_CIRCLE(FLOAT);MY_DB.MY_SCHEMA.AREA_OF_CIRCLE(FLOAT)",
+                    "MY_DB.MY_SCHEMA.OUTPUT_MESSAGE(VARCHAR);MY_DB.MY_SCHEMA.OUTPUT_MESSAGE(VARCHAR)",
+                    "DB.TEST.PYTHON_ADD1(NUMBER, VARCHAR);DB.TEST.PYTHON_ADD1(NUMBER, VARCHAR)",
+                    "DB.GOV.SP_APPLY_ROW_ACCESS_POLICY(VARCHAR, VARCHAR, ARRAY);DB.GOV.SP_APPLY_ROW_ACCESS_POLICY(VARCHAR, VARCHAR, ARRAY)",
+                    "FOO.BAR.ZAR();FOO.BAR.ZAR()",
+                    "SNOWFLAKE.CORE.AVG(TABLE(FLOAT));SNOWFLAKE.CORE.AVG(TABLE(FLOAT))",
+                    "SNOWFLAKE.CORE.AVG(TABLE(FLOAT), TABLE(FLOAT, VARCHAR, NUMBER(38,2)));SNOWFLAKE.CORE.AVG(TABLE(FLOAT), TABLE(FLOAT, VARCHAR, NUMBER(38,2)))",
+                    "FOO.BAR.DUPLICATE_COUNT(TABLE(FLOAT));FOO.BAR.DUPLICATE_COUNT(TABLE(FLOAT))"}, delimiter = ';')
     void procedureGrantNameToObjectName(String input, String expected) {
         String actual = ObjectName.procedureGrantNameToObjectName(input);
         assertEquals(expected, actual);

--- a/src/test/java/us/zoom/data/dfence/test/fixtures/TestRunFixture.java
+++ b/src/test/java/us/zoom/data/dfence/test/fixtures/TestRunFixture.java
@@ -14,6 +14,8 @@ public record TestRunFixture(
         String procedureName,
         String procedureNameShowGrantsQual,
         String procedureNameNoArgsShowGrantsQual,
+        String procedureNameNewFormatQual,
+        String procedureNameNoArgsNewFormatQual,
         LifecycleManager lifecycleManager
 ) {
     /**

--- a/src/test/java/us/zoom/data/dfence/test/fixtures/TestRunFixtureBuilder.java
+++ b/src/test/java/us/zoom/data/dfence/test/fixtures/TestRunFixtureBuilder.java
@@ -157,6 +157,7 @@ public class TestRunFixtureBuilder {
         }
 
         String procedureName = procedureNamePartial + "(STRING, STRING, NUMBER)";
+        // Old format (pre-BCR-2190): DB.SCHEMA."NAME(ARG_NAME TYPE, ...):RETURN_TYPE"
         String procedureNameShowGrantsQual = String.format(
                 "%s.%s.\"%s(FROM_TABLE VARCHAR, TO_TABLE VARCHAR, COUNT NUMBER):VARCHAR\"",
                 databaseName,
@@ -164,6 +165,17 @@ public class TestRunFixtureBuilder {
                 procedureNamePartial);
         String procedureNameNoArgsShowGrantsQual = String.format(
                 "%s.%s.\"%s():VARCHAR\"",
+                databaseName,
+                schemaName,
+                procedureNamePartial);
+        // New format (BCR-2190): DB.SCHEMA.NAME(TYPES) — no quotes, no arg names, no return type
+        String procedureNameNewFormatQual = String.format(
+                "%s.%s.%s(VARCHAR, VARCHAR, NUMBER)",
+                databaseName,
+                schemaName,
+                procedureNamePartial);
+        String procedureNameNoArgsNewFormatQual = String.format(
+                "%s.%s.%s()",
                 databaseName,
                 schemaName,
                 procedureNamePartial);
@@ -181,6 +193,8 @@ public class TestRunFixtureBuilder {
                 procedureName,
                 procedureNameShowGrantsQual,
                 procedureNameNoArgsShowGrantsQual,
+                procedureNameNewFormatQual,
+                procedureNameNoArgsNewFormatQual,
                 lifecycleManager
         );
     }

--- a/src/test/java/us/zoom/data/systemtest/BaseGrantSystemTest.java
+++ b/src/test/java/us/zoom/data/systemtest/BaseGrantSystemTest.java
@@ -48,6 +48,28 @@ public abstract class BaseGrantSystemTest extends SnowflakeSysTestBase {
     }
 
     /**
+     * Asserts that the actual grants match one of the expected grant sets.
+     * This is useful when the Snowflake instance may return either old or new format
+     * procedure names (BCR-2190 backward compatibility).
+     *
+     * @param actualGrants The actual grants from Snowflake
+     * @param expectedGrantSets Multiple possible expected grant lists (e.g., old format, new format)
+     */
+    protected static void assertGrantsMatchAny(List<Grant> actualGrants, List<List<Grant>> expectedGrantSets) {
+        AssertionError lastError = null;
+        for (List<Grant> expectedGrants : expectedGrantSets) {
+            try {
+                assertGrantsMatch(actualGrants, expectedGrants);
+                return; // Match found
+            } catch (AssertionError e) {
+                lastError = e;
+            }
+        }
+        // None matched — throw the last error for diagnostics
+        throw lastError;
+    }
+
+    /**
      * Asserts that the actual grants match the expected grants.
      * Sorts both lists before comparison to ensure order doesn't matter.
      * 

--- a/src/test/java/us/zoom/data/systemtest/TestCreateGrantsSystemTest.java
+++ b/src/test/java/us/zoom/data/systemtest/TestCreateGrantsSystemTest.java
@@ -148,7 +148,8 @@ public class TestCreateGrantsSystemTest extends BaseGrantSystemTest {
 
         // Validate that the role has all the expected grants from the playbook.
         // The playbook includes database, schema (with create semantic view/agent), table, procedure
-        List<Grant> grantsExpected = new ArrayList<>(List.of(
+        // Snowflake may return either old format (pre-BCR-2190) or new format (BCR-2190) procedure names.
+        List<Grant> nonProcGrants = List.of(
                 new Grant("USAGE", "DATABASE", fixture.databaseName(), "ROLE", fixture.roleName()),
                 new Grant("MONITOR", "DATABASE", fixture.databaseName(), "ROLE", fixture.roleName()),
                 new Grant("USAGE", "SCHEMA", fixture.qualifiedSchemaName(), "ROLE", fixture.roleName()),
@@ -156,14 +157,25 @@ public class TestCreateGrantsSystemTest extends BaseGrantSystemTest {
                 new Grant("CREATE SEMANTIC VIEW", "SCHEMA", fixture.qualifiedSchemaName(), "ROLE", fixture.roleName()),
                 new Grant("CREATE AGENT", "SCHEMA", fixture.qualifiedSchemaName(), "ROLE", fixture.roleName()),
                 new Grant("SELECT", "TABLE", fixture.qualifiedTableName(), "ROLE", fixture.roleName()),
-                new Grant("INSERT", "TABLE", fixture.qualifiedTableName(), "ROLE", fixture.roleName()),
+                new Grant("INSERT", "TABLE", fixture.qualifiedTableName(), "ROLE", fixture.roleName())
+        );
+
+        // Old format procedure grants
+        List<Grant> grantsExpectedOld = new ArrayList<>(nonProcGrants);
+        grantsExpectedOld.addAll(List.of(
                 new Grant("USAGE", "PROCEDURE", fixture.procedureNameShowGrantsQual(), "ROLE", fixture.roleName()),
                 new Grant("USAGE", "PROCEDURE", fixture.procedureNameNoArgsShowGrantsQual(), "ROLE", fixture.roleName())
         ));
-        grantsExpected.sort(Comparator.comparing(x -> x.toString().hashCode()));
+
+        // New format procedure grants (BCR-2190)
+        List<Grant> grantsExpectedNew = new ArrayList<>(nonProcGrants);
+        grantsExpectedNew.addAll(List.of(
+                new Grant("USAGE", "PROCEDURE", fixture.procedureNameNewFormatQual(), "ROLE", fixture.roleName()),
+                new Grant("USAGE", "PROCEDURE", fixture.procedureNameNoArgsNewFormatQual(), "ROLE", fixture.roleName())
+        ));
 
         List<Grant> grants = getRoleGrants(fixture.roleName(), securityadminSnowflakeConnectionProvider);
-        assertGrantsMatch(grants, grantsExpected);
+        assertGrantsMatchAny(grants, List.of(grantsExpectedOld, grantsExpectedNew));
     }
 
 }

--- a/src/test/java/us/zoom/data/systemtest/TestRunSystemTest.java
+++ b/src/test/java/us/zoom/data/systemtest/TestRunSystemTest.java
@@ -127,23 +127,37 @@ public class TestRunSystemTest extends BaseGrantSystemTest {
         Assert.assertTrue(newChanges.changes().isEmpty(), "Expected no remaining changes after apply");
 
         // Validate that the role has the expected grants.
-        List<Grant> grantsExpected = new ArrayList<>(List.of(
+        // Snowflake may return either old format (pre-BCR-2190) or new format (BCR-2190) procedure names.
+        List<Grant> nonProcGrants = List.of(
                 new Grant("USAGE", "DATABASE", fixture.databaseName(), "ROLE", fixture.roleName()),
                 new Grant("MONITOR", "DATABASE", fixture.databaseName(), "ROLE", fixture.roleName()),
                 new Grant("USAGE", "SCHEMA", fixture.qualifiedSchemaName(), "ROLE", fixture.roleName()),
                 new Grant("MONITOR", "SCHEMA", fixture.qualifiedSchemaName(), "ROLE", fixture.roleName()),
                 new Grant("CREATE SEMANTIC VIEW", "SCHEMA", fixture.qualifiedSchemaName(), "ROLE", fixture.roleName()),
                 new Grant("SELECT", "TABLE", fixture.qualifiedTableName(), "ROLE", fixture.roleName()),
-                new Grant("OWNERSHIP", "TABLE", fixture.qualifiedTableName(), "ROLE", fixture.roleName()),
+                new Grant("OWNERSHIP", "TABLE", fixture.qualifiedTableName(), "ROLE", fixture.roleName())
+        );
+
+        // Old format procedure grants
+        List<Grant> grantsExpectedOld = new ArrayList<>(nonProcGrants);
+        grantsExpectedOld.addAll(List.of(
                 new Grant("USAGE", "PROCEDURE", fixture.procedureNameShowGrantsQual(), "ROLE", fixture.roleName()),
                 new Grant("USAGE", "PROCEDURE", fixture.procedureNameNoArgsShowGrantsQual(), "ROLE", fixture.roleName()),
                 new Grant("OWNERSHIP", "PROCEDURE", fixture.procedureNameShowGrantsQual(), "ROLE", fixture.roleName()),
                 new Grant("OWNERSHIP", "PROCEDURE", fixture.procedureNameNoArgsShowGrantsQual(), "ROLE", fixture.roleName())
         ));
-        grantsExpected.sort(Comparator.comparing(x -> x.toString().hashCode()));
+
+        // New format procedure grants (BCR-2190)
+        List<Grant> grantsExpectedNew = new ArrayList<>(nonProcGrants);
+        grantsExpectedNew.addAll(List.of(
+                new Grant("USAGE", "PROCEDURE", fixture.procedureNameNewFormatQual(), "ROLE", fixture.roleName()),
+                new Grant("USAGE", "PROCEDURE", fixture.procedureNameNoArgsNewFormatQual(), "ROLE", fixture.roleName()),
+                new Grant("OWNERSHIP", "PROCEDURE", fixture.procedureNameNewFormatQual(), "ROLE", fixture.roleName()),
+                new Grant("OWNERSHIP", "PROCEDURE", fixture.procedureNameNoArgsNewFormatQual(), "ROLE", fixture.roleName())
+        ));
 
         List<Grant> grants = getRoleGrants(fixture.roleName(), securityadminSnowflakeConnectionProvider);
-        assertGrantsMatch(grants, grantsExpected);
+        assertGrantsMatchAny(grants, List.of(grantsExpectedOld, grantsExpectedNew));
     }
 
     @Test(dependsOnMethods = {"testApply"}, groups = {"a"})
@@ -175,15 +189,19 @@ public class TestRunSystemTest extends BaseGrantSystemTest {
 
         // Validate that role1 has no grants (all revoked)
         List<Grant> grantsExpectedRole1 = new ArrayList<>(List.of());
-        grantsExpectedRole1.sort(Comparator.comparing(x -> x.toString().hashCode()));
 
         // Validate that role2 has ownership grants (transferred from role1)
-        List<Grant> grantsExpectedRole2 = new ArrayList<>(List.of(
+        // Snowflake may return either old or new format procedure names (BCR-2190)
+        List<Grant> grantsExpectedRole2Old = new ArrayList<>(List.of(
                 new Grant("OWNERSHIP", "TABLE", fixture.qualifiedTableName(), "ROLE", fixture.roleName2()),
                 new Grant("OWNERSHIP", "PROCEDURE", fixture.procedureNameShowGrantsQual(), "ROLE", fixture.roleName2()),
                 new Grant("OWNERSHIP", "PROCEDURE", fixture.procedureNameNoArgsShowGrantsQual(), "ROLE", fixture.roleName2())
         ));
-        grantsExpectedRole2.sort(Comparator.comparing(x -> x.toString().hashCode()));
+        List<Grant> grantsExpectedRole2New = new ArrayList<>(List.of(
+                new Grant("OWNERSHIP", "TABLE", fixture.qualifiedTableName(), "ROLE", fixture.roleName2()),
+                new Grant("OWNERSHIP", "PROCEDURE", fixture.procedureNameNewFormatQual(), "ROLE", fixture.roleName2()),
+                new Grant("OWNERSHIP", "PROCEDURE", fixture.procedureNameNoArgsNewFormatQual(), "ROLE", fixture.roleName2())
+        ));
 
         // Snowflake appears to have eventual consistency on this metadata after the ownership change.
         // We need to wait for the metadata to catch up.
@@ -199,7 +217,7 @@ public class TestRunSystemTest extends BaseGrantSystemTest {
 
                 // Verify role2 has ownership grants
                 List<Grant> grantsRole2 = getRoleGrants(fixture.roleName2(), securityadminSnowflakeConnectionProvider);
-                assertGrantsMatch(grantsRole2, grantsExpectedRole2);
+                assertGrantsMatchAny(grantsRole2, List.of(grantsExpectedRole2Old, grantsExpectedRole2New));
                 
                 success = true;
             } catch (AssertionError e) {


### PR DESCRIPTION
## Summary

Snowflake BCR 2026_01 (bcr-2190) changed the `SHOW GRANTS` output format for procedures/functions.

**Old format (pre-BCR 2026_01):**
```
DB.SCHEMA."MY_PROC(ARG1 VARCHAR, ARG2 NUMBER):VARCHAR"
```
Quoted 3rd part containing function name, arg names + types, colon, return type.

**New format (BCR 2026_01+):**
```
DB.SCHEMA.MY_PROC(VARCHAR, NUMBER)
```
Unquoted, just arg types, no arg names, no return type.

Both formats are now supported for backward compatibility during the Snowflake BCR rollout period.

### Approach

No new ANTLR grammar is needed. The existing `ObjectName.g4` already handles the new format via its `args?` production: `objectName : part (DOT part)* args? EOF`.

**Detection uses `SqlObject.hasArguments` as the discriminator.** This boolean flag indicates whether the parser matched a parenthesized argument list (the `args` production), not whether the arguments list is non-empty:

| Input | `hasArguments` | `arguments` | Why |
|---|---|---|---|
| `DB.SCHEMA.NAME(VARCHAR, NUMBER)` | `true` | `[VARCHAR, NUMBER]` | New format — `args` production matched |
| `DB.SCHEMA.NAME()` | `true` | `[]` | New format with no args — parens present, `args` matched |
| `DB.SCHEMA.NAME` | `false` | `[]` | Regular object name — no parens |
| `DB.SCHEMA."NAME(ARG TYPE):RET"` | `false` | `[]` | Old format — parens are inside the quoted identifier, so `ObjectName.g4` treats the whole thing as a single `QUOTED_IDENTIFIER` part, never hitting the `args` production |

The last case is key: when the old format is parsed by `ObjectName.g4`, the third part is a `QUOTED_IDENTIFIER` that swallows everything including the parentheses. The grammar never sees `args`, so `hasArguments` stays `false`. This makes it a reliable discriminator.

**`procedureGrantNameToObjectName()` logic:**
1. Parse with `ObjectName.g4` (standard grammar)
2. If `hasArguments == true` → new format, return normalized name
3. If `hasArguments == false` → fall through to `ShowGrantsProcedureName.g4` (old format parser)

`ShowGrantsProcedureName.g4` is **not** extended because:
- The new format is structurally different (no quoted wrapper, no arg names, no return type)
- `ObjectName.g4` already handles it correctly
- Adding redundant parsing paths would create maintenance burden with no benefit

### Changes

- **`ObjectName.java`** — Updated `procedureGrantNameToObjectName()` to try new format first (via `parseSqlObject()`), fall back to old format (via `parseSqlObjectFromShowGrantsProcedureName()`)
- **`ObjectNameTest.java`** — Added 8 new-format parameterized test cases (simple types, no-args, nested `TABLE(FLOAT)`, compound types)
- **`SnowflakeGrantsServiceTest.java`** — Added `getGrantsWithNewFormatProcedureName()` and `getGrantsWithOldFormatProcedureName()` tests exercising the full `getGrants()` pipeline with mock ResultSets
- **`TestRunFixture.java`** — Added `procedureNameNewFormatQual` and `procedureNameNoArgsNewFormatQual` fields
- **`TestRunFixtureBuilder.java`** — Builds new-format procedure name strings alongside old-format ones
- **`BaseGrantSystemTest.java`** — Added `assertGrantsMatchAny()` helper for either-format matching in system tests
- **`TestRunSystemTest.java`** — Updated `testApply` and `testApplyRevoke` to accept old or new format from live Snowflake
- **`TestCreateGrantsSystemTest.java`** — Updated `testApply` to accept old or new format

Reference: https://docs.snowflake.com/en/release-notes/bcr-bundles/2026_01/bcr-2190

## Test plan
- [x] 748 unit tests pass (`mvn package -DskipSystemTests=true`)
- [ ] Integration tests against live Snowflake (system tests accept either format)