### PR TITLE
Add DYNAMIC_TABLE to SnowflakeObjectType enum

### DIFF
--- a/src/main/java/us/zoom/data/dfence/providers/snowflake/grant/builder/SnowflakeObjectType.java
+++ b/src/main/java/us/zoom/data/dfence/providers/snowflake/grant/builder/SnowflakeObjectType.java
@@ -36,6 +36,7 @@ public enum SnowflakeObjectType {
     DATABASE(1, null),
     DATABASE_ROLE(2, null),
     DIRECTORY_TABLE(3, null),
+    DYNAMIC_TABLE(3, "TABLE"),
     EVENT_TABLE(3, null),
     EXTERNAL_TABLE(3, "TABLE"),
     FILE_FORMAT(3, null),

--- a/src/test/java/us/zoom/data/dfence/providers/snowflake/revoke/factories/SnowflakeGrantFactoryTest.java
+++ b/src/test/java/us/zoom/data/dfence/providers/snowflake/revoke/factories/SnowflakeGrantFactoryTest.java
@@ -137,6 +137,18 @@ class SnowflakeGrantFactoryTest {
   }
 
   @Test
+  void from_shouldHandleDynamicTable() {
+    SnowflakeGrantModel model =
+        new SnowflakeGrantModel(
+            "SELECT", "DYNAMIC_TABLE", "DB.SCHEMA.MY_DT", "ROLE", "USER", false, false, false);
+
+    SnowflakeGrant result = SnowflakeGrantFactory.createFrom(model);
+
+    assertEquals(SnowflakeObjectType.DYNAMIC_TABLE, result.snowflakeObjectType());
+    assertEquals("SELECT", result.privilege().value());
+  }
+
+  @Test
   void from_shouldValidateContainerQualLevel1() {
     // Valid: Object Schema (level 2) -> Container DB (level 1)
     SnowflakeGrantModel model =


### PR DESCRIPTION
## Summary
- Adds `DYNAMIC_TABLE(3, "TABLE")` to the `SnowflakeObjectType` enum so that grants on Snowflake dynamic tables are correctly parsed from `SHOW GRANTS` output.
- Without this, `DYNAMIC_TABLE` grants fail to convert and are silently dropped during revocation evaluation.
- Includes unit test verifying the new object type is handled by `SnowflakeGrantFactory`.

## Test plan
- [x] Unit tests pass (739 tests, 0 failures)
- [x] Integration tests against Snowflake account with dynamic table grants